### PR TITLE
add initial clone implementation

### DIFF
--- a/internal/finder/find.go
+++ b/internal/finder/find.go
@@ -15,9 +15,10 @@ type Walker struct {
 }
 
 type state struct {
-	pack       string
-	paramLists map[*ast.FieldList][]*ast.Field // map of field list to specific fields to rename
-	funcLists  map[*ast.FuncDecl]interface{}   // map of field list to specific fields to rename
+	pack        string
+	paramLists  map[*ast.FieldList][]*ast.Field // map of field list to specific fields to rename
+	funcLists   map[*ast.FuncDecl]interface{}   // map of field list to specific fields to rename
+	assignments map[*ast.Field][]*ast.AssignStmt
 }
 
 func renameModelParameter(field *ast.Field) *ast.Field {
@@ -35,7 +36,8 @@ func renameModelParameter(field *ast.Field) *ast.Field {
 }
 
 func addCloneToBlock(block *ast.BlockStmt, fields []*ast.Field) *ast.BlockStmt {
-	assignments := []ast.Stmt{}
+	var assignments []ast.Stmt
+
 	for _, field := range fields {
 		assignments = append(assignments, &ast.AssignStmt{
 			Tok: token.DEFINE,
@@ -61,10 +63,96 @@ func addCloneToBlock(block *ast.BlockStmt, fields []*ast.Field) *ast.BlockStmt {
 	}
 }
 
+func migrateClone(typeName string, block *ast.BlockStmt, field *ast.Field, assigns []*ast.AssignStmt) *ast.BlockStmt {
+	list := make([]ast.Stmt, len(block.List))
+	copy(list, block.List)
+	var args []ast.Expr
+	var insert int
+
+	for i, stmt := range list {
+		as, ok := stmt.(*ast.AssignStmt)
+		if !ok {
+			continue
+		}
+		for _, assign := range assigns {
+			if as == assign {
+				sel, ok := assign.Lhs[0].(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+				name := "new" + sel.Sel.Name
+				list[i] = &ast.AssignStmt{
+					Tok: token.DEFINE,
+					Lhs: []ast.Expr{
+						&ast.Ident{
+							Name: name,
+						},
+					},
+					Rhs: assign.Rhs,
+				}
+				args = append(args, &ast.KeyValueExpr{
+					Key: &ast.Ident{
+						Name: sel.Sel.Name,
+					},
+					Value: &ast.Ident{
+						Name: name,
+					},
+				})
+				insert = i
+			}
+		}
+	}
+	if len(args) > 0 {
+		insert++ // add one after
+		list = append(list[:insert], append([]ast.Stmt{&ast.AssignStmt{
+			Tok: token.DEFINE,
+			Lhs: []ast.Expr{
+				&ast.Ident{
+					Name: field.Names[0].Name,
+				},
+			},
+			Rhs: []ast.Expr{
+				&ast.CallExpr{
+					Fun: &ast.SelectorExpr{
+						X:   &ast.Ident{Name: "_" + field.Names[0].Name},
+						Sel: &ast.Ident{Name: "Apply"},
+					},
+					Args: []ast.Expr{
+						&ast.UnaryExpr{
+							X: &ast.CompositeLit{
+								Type: &ast.SelectorExpr{
+									X: &ast.Ident{
+										Name: "model",
+									},
+									Sel: &ast.Ident{
+										Name: typeName + "Patch",
+									},
+								},
+								Elts: args,
+							},
+							Op: token.AND,
+						},
+					},
+				},
+			},
+		},
+		}, list[insert:]...)...)
+	}
+
+	return &ast.BlockStmt{
+		Lbrace: block.Lbrace,
+		Rbrace: block.Rbrace,
+		List:   list,
+	}
+}
+
 func (w *Walker) pre(c *astutil.Cursor) bool {
 	if parentFunc, ok := c.Parent().(*ast.FuncDecl); ok && w.funcLists[parentFunc] == parentFunc {
 		if stmt, ok := c.Node().(*ast.BlockStmt); ok {
-			c.Replace(addCloneToBlock(stmt, w.paramLists[parentFunc.Type.Params]))
+			for field, assigns := range w.assignments {
+				c.Replace(migrateClone(w.Name, stmt, field, assigns))
+			}
+			// c.Replace(addCloneToBlock(stmt, w.paramLists[parentFunc.Type.Params]))
 			return true
 		}
 	}
@@ -83,7 +171,11 @@ func (w *Walker) pre(c *astutil.Cursor) bool {
 		}
 		fmt.Printf("pkg: %s, fn: %s\n", w.pack, fdecl.Name)
 
-		w.paramLists[fdecl.Type.Params] = fields
+		for field, assignments := range fields {
+			w.assignments[field] = assignments
+			w.paramLists[fdecl.Type.Params] = append(w.paramLists[fdecl.Type.Params], field)
+		}
+
 		w.funcLists[fdecl] = fdecl
 	}
 	return true
@@ -96,6 +188,7 @@ func (w *Walker) post(c *astutil.Cursor) bool {
 func (w *Walker) Process(root ast.Node) ast.Node {
 	w.paramLists = make(map[*ast.FieldList][]*ast.Field)
 	w.funcLists = make(map[*ast.FuncDecl]interface{})
+	w.assignments = make(map[*ast.Field][]*ast.AssignStmt)
 	w.pack = root.(*ast.File).Name.Name
 	return astutil.Apply(root, w.pre, w.post)
 }


### PR DESCRIPTION
This is not complete, need to use `model.NewString("foo")` in the patch, but it's not easy to detect actual type in `ast`. (e.g. `channel.Foo = os.Args[0]`)

For now this PR adds ability to convert this:
```golang
func Break(channel *model.Channel) (*model.Channel, error) {
	channel.Name = "updated"
	fmt.Println("channel name updated")
	channel.F1 = 5
	fmt.Println("some filed updated again")
	fmt.Printf("F4:%t\n", channel.F4)
	return channel, nil
}
```
to this:
```golang
func Break(_channel *model.Channel) (*model.Channel, error) {
	newName := "updated"
	fmt.Println("channel name updated")
	newF1 := 5
	channel := _channel.Apply(&model.ChannelPatch{Name: newName, F1: newF1})
	fmt.Println("some filed updated again")
	fmt.Printf("F4:%t\n", channel.F4)
	return channel, nil
}
```